### PR TITLE
Test routine for the factorial integer input experiment

### DIFF
--- a/staging/dwtools/amath/arithmetic.test/aScalar.test.s
+++ b/staging/dwtools/amath/arithmetic.test/aScalar.test.s
@@ -332,6 +332,22 @@ function floorToPowerOfTwo( test )
 }
 
 
+function experiment( test )
+{  /*
+   *  Why does it show an error for the decimal argument if there i no requirement in the code for it to be integer (even if it should)?
+   */
+
+  if( !Config.debug )
+  return;
+
+  test.description = 'decimal argument';
+  test.shouldThrowError( function()
+  {
+  _.factorial( 2.5 )
+  });
+
+}
+
 // --
 // proto
 // --


### PR DESCRIPTION
Experiment routine included to test:

There is no requirement in the code for the input to be an integer (but it should). However, when we run the test, it triggers an error. Why?